### PR TITLE
Refactor AuthService to return full response object in pingAdmin function and to only check for 200 response from ping-admin endpoint

### DIFF
--- a/frontend/occupi-web/src/AuthService.ts
+++ b/frontend/occupi-web/src/AuthService.ts
@@ -373,7 +373,7 @@ const AuthService = {
       const response = await axios.get(`/ping-admin`, {
         withCredentials: true,
       });
-      return response.data;
+      return response;
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.data) {
         throw error.response.data;

--- a/frontend/occupi-web/src/components/protectedRoutes/ProtectedRoutes.tsx
+++ b/frontend/occupi-web/src/components/protectedRoutes/ProtectedRoutes.tsx
@@ -16,7 +16,7 @@ const ProtectedRoute = (props: ProtectedRouteProps) => {
     const checkAuthentication = async () => {
       if(userDetails === null){
         const res = await AuthService.pingAdmin();
-        if (res.status === 200 && res.message === "pong -> I am alive and kicking and you are an admin") {
+        if (res.status === 200) {
           const userDeets = await AuthService.getUserDetails();
           setUserDetails(userDeets);
         } else {


### PR DESCRIPTION
# Description

This pr aims to HOT-FIX a slight issue that would occur with session checking for admins on web by only checking the status of the response instead of matching the response as well.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
